### PR TITLE
Fix code scanning alert no. 9: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/modules/javafx.web/src/main/native/Source/WTF/Scripts/generate-unified-source-bundles.rb
+++ b/modules/javafx.web/src/main/native/Source/WTF/Scripts/generate-unified-source-bundles.rb
@@ -216,9 +216,9 @@ class BundleManager
             $outputSources << bundleFile
             return
         end
-        if (!bundleFile.exist? || IO::read(bundleFile) != @currentBundleText)
+        if (!bundleFile.exist? || File.read(bundleFile) != @currentBundleText)
             log("Writing bundle #{bundleFile} with: \n#{@currentBundleText}")
-            IO::write(bundleFile, @currentBundleText)
+            File.write(bundleFile, @currentBundleText)
         end
     end
 


### PR DESCRIPTION
Fixes [https://github.com/rncscox/rncs_jfx/security/code-scanning/9](https://github.com/rncscox/rncs_jfx/security/code-scanning/9)

To fix the problem, we should replace the use of `IO.write` with `File.write`. This change ensures that the file name is not interpreted as a command, mitigating the risk of arbitrary code execution. The change should be made in the `writeFile` method of the `BundleManager` class.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
