### PR TITLE
Fix code scanning alert no. 6: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/modules/javafx.web/src/main/native/Source/JavaScriptCore/offlineasm/parser.rb
+++ b/modules/javafx.web/src/main/native/Source/JavaScriptCore/offlineasm/parser.rb
@@ -921,7 +921,7 @@ class Parser
 end
 
 def readTextFile(fileName)
-    data = IO::read(fileName)
+    data = File.read(fileName)
 
     # On Windows, files may contain CRLF line endings (for example, git client might
     # automatically replace \n with \r\n on Windows) which will fail our parsing.


### PR DESCRIPTION
Fixes [https://github.com/rncscox/rncs_jfx/security/code-scanning/6](https://github.com/rncscox/rncs_jfx/security/code-scanning/6)

To fix the problem, we need to replace the use of `IO.read` with `File.read`. This change will mitigate the security risk associated with executing arbitrary shell commands when the file name starts with a `|` character. The functionality of reading the file content remains the same, but the security risk is eliminated.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
